### PR TITLE
Respect context options when using extends with relative paths

### DIFF
--- a/core/middleware/index.js
+++ b/core/middleware/index.js
@@ -1,6 +1,7 @@
 var jade = require('jade');
 var path = require('path');
 var specUtils = require(path.join(global.pathToApp,'core/lib/specUtils'));
+var configUtils = require(path.join(global.pathToApp, 'core/lib/configUtils'));
 
 /*
  * Get html from response and parse jade markup
@@ -14,7 +15,8 @@ exports.process = function (req, res, next) {
         if (req.specData.isJade || req.specData.isPug) {
             var html = req.specData.renderedHtml;
             var specDir = specUtils.getFullPathToSpec(req.path);
-            var specFilePath = specUtils.getSpecFromDir(specDir);
+            var specFiles = configUtils.getContextOptions(req.path).rendering.specFiles;
+            var specFilePath = specUtils.getSpecFromDir(specDir, specFiles);
 
             /* render jade markup */
             html = jade.render(html, {


### PR DESCRIPTION
`specUtils.getSpecFromDir` fails to return the correct spec file path when the list of supported filenames is overridden for the context (in `sourcejs-options.js`). 

It either looks for a spec file using the default list of supported spec names (defined in `options.js`) or the one passed as the second argument ([see](https://github.com/sourcejs/Source/blob/eeb423b47a5a4be4757c47f87d349aaff74eed5e/core/lib/specUtils.js#L78)).
```js
module.exports.getSpecFromDir = function(dirPath, specFiles) {
  // ...
  var supportedSpecNames = specFiles || global.opts.rendering.specFiles;
  // ...
}
```
Empty `specFilePath` results into Jade error when using `extends` inside a spec template: 
`the "filename" option is required to use "extends" with "relative" paths`.
```js
var specFilePath = specUtils.getSpecFromDir(specDir);

/* render jade markup */
html = jade.render(html, {
    // ...
    filename: specFilePath
});
```
This PR adds support for context-specific `rendering.specFiles` option by passing it into `specUtils.getSpecFromDir` as a second argument.